### PR TITLE
Fix total sector size configurations for 1114/323 and 1114/333 chips.

### DIFF
--- a/lpcprog.c
+++ b/lpcprog.c
@@ -126,8 +126,8 @@ static LPC_DEVICE_TYPE LPCtypes[] =
 
    { 0x00040042, "1114.../203",  32,  8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
    { 0x00040040, "1114.../303",  32,  8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040060, "1114.../323",  32,  8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040070, "1114.../333",  32,  8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040060, "1114.../323",  32,  8, 12, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040070, "1114.../333",  32,  8, 14, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
    { 0x00050080, "1115.../303",  64,  8, 16, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX }, 
    
    { 0x1421102B, "11C12.../301",  16,  8,  4, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },


### PR DESCRIPTION
Hi,
The total sector size was set incorrectly for the 1114.../323 and 1114.../333 chips, this commit fixes it. Let me know if there are any issues.
Thanks!
