### PR TITLE
Makefile: support compiling lpc21isp in OS X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,11 @@ endif
 
 ifneq ($(findstring Darwin,$(OSTYPE)),)
 CFLAGS+=-D__APPLE__
+else
+CFLAGS+=-static
 endif
 
-CFLAGS	+= -Wall -static
+CFLAGS	+= -Wall
 
 adprog.o: adprog.c $(GLOBAL_DEP)
 	$(CC) $(CDEBUG) $(CFLAGS) -c -o adprog.o adprog.c


### PR DESCRIPTION
Allows lpc21isp to compile successfully in OS X by selectively disabling static linking.

Makefile changes originally made by adamgreen @ https://github.com/adamgreen/lpc21isp/commit/01530aa94fefe5bd7366300735c27026b88c4355
