### PR TITLE
ReceiveComPort() should request the number of bytes required, not one le...

### DIFF
--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -1211,7 +1211,7 @@ void ReceiveComPort(ISP_ENVIRONMENT *IspEnvironment,
         if (residual_data[0] == '\0')
         {
             /* Receive new data */
-            ReceiveComPortBlock(IspEnvironment, Answer + (*RealSize), MaxSize - 1 - (*RealSize), &tmp_realsize);
+            ReceiveComPortBlock(IspEnvironment, Answer + (*RealSize), MaxSize - (*RealSize), &tmp_realsize);
         }
         else
         {


### PR DESCRIPTION
...ss.

By requesting one less byte than the number required, the Linux code was
hanging up because the select() call was always succeeding (when data was
available) so it never timed out and then the zero-length read() succeeded
but the buffer is never filled.

Hi Martin,

I see that 1.94 now uses select() for Linux com port timeouts so my last patch is redundant. OK, that's fine but, unfortunately, 1.94 was hanging up like the unpatched 1.92 did so I looked into it and found that ReceiveComPort() was reading one less character than it should which didn't matter when using the counter for timeouts but broke with the new select code because it meant that the select would succeed (assuming data was available) but then the read was zero length and so *RealSize would never equal MaxSize and it would be stuck in the loop forever.

Cheers,

Mark
