### PR TITLE
modified for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 CFLAGS		+= -Wall
 
-ifneq ($(findstring Darwin,$(OSTYPE)),)
+ifneq ($(findstring darwin,$(OSTYPE)),)
 CFLAGS+=-D__APPLE__
 else
 CFLAGS		+= -static


### PR DESCRIPTION
To build on Mac OS X, Makefile modification was required. 
This is a small modification to detect the OSTYPE correctly. 