### PR TITLE
Add Cortex-M MCU reset and add LPC11x6x devices

### DIFF
--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -1417,6 +1417,13 @@ static void ReadArguments(ISP_ENVIRONMENT *IspEnvironment, unsigned int argc, ch
                 continue;
             }
 
+            if (stricmp(argv[i], "-reset") == 0)
+            {
+                IspEnvironment->DoReset = 1;
+                DebugPrintf(3, "Reset the MCU core after programming.\n");
+                continue;
+            }
+
             if(strnicmp(argv[i],"-try", 4) == 0)
             {
                 int
@@ -1598,6 +1605,7 @@ static void ReadArguments(ISP_ENVIRONMENT *IspEnvironment, unsigned int argc, ch
                        "         -debug3      for progress info only\n"
                        "         -debug5      for full debug\n"
                        "         -donotstart  do not start MCU after download\n"
+                       "         -reset       reset the MCU after download\n"
                        "         -try<n>      try n times to synchronise\n"
                        "         -wipe        Erase entire device before upload\n"
                        "         -control     for controlling RS232 lines for easier booting\n"

--- a/lpc21isp.h
+++ b/lpc21isp.h
@@ -176,6 +176,7 @@ typedef struct
     FILE_LIST *f_list;                  // List of files to read in.
     int nQuestionMarks; // how many times to try to synchronise
     int DoNotStart;
+    int DoReset;
     int BootHold;
     char *serial_port;                  // Name of the serial port to use to
                                         // communicate with the microcontroller.

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -90,6 +90,14 @@ static const unsigned int SectorTable_11xx[] =
      4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096
 };
 
+static const unsigned int SectorTable_11x6x[] =
+{
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+    32768, 32768, 32768, 32768, 32768
+};
+
 // Used for LPC17xx devices
 static const unsigned int SectorTable_17xx[] =
 {
@@ -209,6 +217,16 @@ static LPC_DEVICE_TYPE LPCtypes[] =
    { 0x00017C40, 0x00000000, 0, "11U37FBD48/401",                128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
    { 0x00007C44, 0x00000000, 0, "11U37HFBD64/401",               128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
    { 0x00007C40, 0x00000000, 0, "11U37FBD64/501",                128,  12, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+
+   /* LPC11[UE]6x see UM10732 */
+   { 0x0000DCC8, 0x00000000, 0, "11U66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC88, 0x00000000, 0, "11U67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC80, 0x00000000, 0, "11U67JBD100",                   128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C08, 0x00000000, 0, "11U68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C00, 0x00000000, 0, "11U68JBD100",                   256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000DCC1, 0x00000000, 0, "11E66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC81, 0x00000000, 0, "11E67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C01, 0x00000000, 0, "11E68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
 
    { 0x3640C02B, 0x00000000, 0, "1224.../101",                    32,   8,  4, 2048, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
    { 0x3642C02B, 0x00000000, 0, "1224.../121",                    48,  12, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },


### PR DESCRIPTION
Hi,

This PR adds a core reset feature and several LPC devices.

The feature added relates to Cortex-M core reset capability. These cores can be reset by software. The patch adds the download of a reset-routine (described in a comment) and a command-line option "-reset" to activate this behaviour.

There are also added several devices:
- LPC11U6[678]
- LPC11E6[678]
Both 48-, 64- and 100-pin versions are added.

Please consider adding these changes to the distribution.

Thanks,

--
Greetings Bertho