### PR TITLE
Add support for LPC80x, LPC83x and LPC84x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 CFLAGS		+= -Wall
 
-ifneq ($(findstring darwin,$(OSTYPE)),)
+ifneq ($(findstring Darwin,$(OSTYPE)),)
 CFLAGS+=-D__APPLE__
 else
 CFLAGS		+= -static

--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -833,21 +833,23 @@ static void ReceiveComPortBlock(ISP_ENVIRONMENT *IspEnvironment,
             readSet;
         struct timeval
             timeVal;
+        int ret;
 
         FD_ZERO(&readSet);                             // clear the set
         FD_SET(IspEnvironment->fdCom,&readSet);        // add this descriptor to the set
         timeVal.tv_sec=0;                              // set up the timeout waiting for one to come ready (500ms)
         timeVal.tv_usec=500*1000;
-        if(select(FD_SETSIZE,&readSet,NULL,NULL,&timeVal)==1)    // wait up to 500 ms or until our data is ready
+        ret = select(IspEnvironment->fdCom + 1,&readSet,NULL,NULL,&timeVal);    // wait up to 500 ms or until our data is ready
+        if (ret == -1)
         {
-            *real_size=read(IspEnvironment->fdCom, answer, max_size);
+          sprintf(tmp_string, "Select error: %d", errno);
+          DumpString(5, 0, 0, tmp_string);
+          *real_size = 0;
         }
-        else
-        {
-            // timed out, show no characters received and timer expired
+        else if (ret == 0)
             *real_size=0;
-            IspEnvironment->serial_timeout_count=0;
-        }
+        else
+            *real_size=read(IspEnvironment->fdCom, answer, max_size);
     }
 #endif // defined COMPILE_FOR_LINUX
 

--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -829,27 +829,30 @@ static void ReceiveComPortBlock(ISP_ENVIRONMENT *IspEnvironment,
 
 #if defined COMPILE_FOR_LINUX
     {
-        fd_set
-            readSet;
-        struct timeval
-            timeVal;
+        fd_set readSet;
+        struct timeval timeVal;
         int ret;
 
-        FD_ZERO(&readSet);                             // clear the set
-        FD_SET(IspEnvironment->fdCom,&readSet);        // add this descriptor to the set
-        timeVal.tv_sec=0;                              // set up the timeout waiting for one to come ready (500ms)
-        timeVal.tv_usec=500*1000;
-        ret = select(IspEnvironment->fdCom + 1,&readSet,NULL,NULL,&timeVal);    // wait up to 500 ms or until our data is ready
+	// wait up to 500 ms or until our data is ready
+        FD_ZERO(&readSet);
+        FD_SET(IspEnvironment->fdCom, &readSet);
+        timeVal.tv_sec = 0;
+        timeVal.tv_usec = 500 * 1000;
+        ret = select(IspEnvironment->fdCom + 1, &readSet, NULL, NULL, &timeVal);
         if (ret == -1)
         {
-          sprintf(tmp_string, "Select error: %d", errno);
-          DumpString(5, 0, 0, tmp_string);
-          *real_size = 0;
+            sprintf(tmp_string, "Select error: %d", errno);
+            DumpString(5, 0, 0, tmp_string);
+            *real_size = 0;
         }
         else if (ret == 0)
-            *real_size=0;
+	{
+            *real_size = 0;
+	}
         else
-            *real_size=read(IspEnvironment->fdCom, answer, max_size);
+	{
+            *real_size = read(IspEnvironment->fdCom, answer, max_size);
+	}
     }
 #endif // defined COMPILE_FOR_LINUX
 

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -117,6 +117,12 @@ static const unsigned int SectorTable_43xx[] =
 static const unsigned int SectorTable_8xx[] =
 {
      1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
+     1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024,
      1024,  1024,  1024,  1024,  1024,  1024,  1024,  1024
 };
 
@@ -128,6 +134,16 @@ static LPC_DEVICE_TYPE LPCtypes[] =
 
    // id,        id2,  use id2, name of product,          flash size, ram size, total number of sector, max copy size, sector table, chip variant
 
+   { 0x00008021, 0x00000000, 0, "802M001JDH20",                   16,   2, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008022, 0x00000000, 0, "802M011JDH20",                   16,   2, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008023, 0x00000000, 0, "802M001JDH16",                   16,   2, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008024, 0x00000000, 0, "802M001JHI33",                   16,   2, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+
+   { 0x00008041, 0x00000000, 0, "804M101JDH20",                   32,   4, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008042, 0x00000000, 0, "804M101JDH24",                   32,   4, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008043, 0x00000000, 0, "804M111JDH24",                   32,   4, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008044, 0x00000000, 0, "804M101JHI33",                   32,   4, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+
    { 0x00008100, 0x00000000, 0, "810M021FN8",                      4,   1,  4,  256, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
    { 0x00008110, 0x00000000, 0, "811M001FDH16",                    8,   2,  8, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
    { 0x00008120, 0x00000000, 0, "812M101FDH16",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
@@ -138,6 +154,18 @@ static LPC_DEVICE_TYPE LPCtypes[] =
    { 0x00008221, 0x00000000, 0, "822M101JHI33",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
    { 0x00008242, 0x00000000, 0, "824M201JDH20",                   32,   8, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
    { 0x00008222, 0x00000000, 0, "822M101JDH20",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+
+   { 0x00008322, 0x00000000, 0, "832M101FDH20",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008341, 0x00000000, 0, "8341201FHI33",                   32,   4, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+
+   { 0x00008442, 0x00000000, 0, "844M201JBD48",                   64,   8, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008441, 0x00000000, 0, "844M201JBD64",                   64,   8, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008444, 0x00000000, 0, "844M201JHI33",                   64,   8, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008443, 0x00000000, 0, "844M201JHI48",                   64,   8, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008452, 0x00000000, 0, "845M301JBD48",                   64,  16, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008451, 0x00000000, 0, "845M301JBD64",                   64,  16, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008454, 0x00000000, 0, "845M301JHI33",                   64,  16, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008453, 0x00000000, 0, "845M301JHI48",                   64,  16, 64, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
 
    { 0x2500102B, 0x00000000, 0, "1102",                           32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
 

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -1743,7 +1743,21 @@ unsigned long ReturnValueLpcRamBase(ISP_ENVIRONMENT *IspEnvironment)
   }
   else if(LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC8XX)
   {
-    return LPC_RAMBASE_LPC8XX;
+    if ((LPCtypes[IspEnvironment->DetectedDevice].id & 0xffffff00) == 0x00008000)
+    {
+      // LPC80x device
+      return LPC_RAMBASE_LPC80X;
+    }
+    else if ((LPCtypes[IspEnvironment->DetectedDevice].id & 0xffffff00) == 0x00008400)
+    {
+      // LPC84x device
+      return LPC_RAMBASE_LPC84X;
+    }
+    else
+    {
+      // other LPC8xx device
+      return LPC_RAMBASE_LPC8XX;
+    }
   }
   DebugPrintf(1, "Error in ReturnValueLpcRamBase (%d)\n", LPCtypes[IspEnvironment->DetectedDevice].ChipVariant);
   exit(1);

--- a/lpcprog.h
+++ b/lpcprog.h
@@ -63,6 +63,8 @@ Portions Copyright (c) by Aeolus Development 2004 http://www.aeolusdevelopment.c
 
 #define LPC_RAMSTART_LPC8XX     0x10000000L
 #define LPC_RAMBASE_LPC8XX      0x10000270L
+#define LPC_RAMBASE_LPC80X      0x100003A8L
+#define LPC_RAMBASE_LPC84X      0x10000600L
 
 /* Return values used by NxpDownload(): reserving all values from 0x1000 to 0x1FFF */
 


### PR DESCRIPTION
This is tested with LPC804 and LPC845 using an FTDI dongle.
LPC83x is untested.
