### PR TITLE
fix lpc18xx id and id2 Hex coding Word0 and Word1

### DIFF
--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -704,7 +704,7 @@ void SendComPortBlock(ISP_ENVIRONMENT *IspEnvironment, const void *s, size_t n)
     char * rxpch;
 #endif // defined COMPILE_FOR_WINDOWS || defined COMPILE_FOR_CYGWIN
 
-    DumpString(4, s, n, "Sending ");
+    DumpString(3, s, n, "Sending ");
 
 #if defined COMPILE_FOR_WINDOWS || defined COMPILE_FOR_CYGWIN
 

--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -415,7 +415,7 @@ Change-History:
 // Please don't use TABs in the source code !!!
 
 // Don't forget to update the version string that is on the next line
-#define VERSION_STR "1.97"
+#define VERSION_STR "1.98"
 
 #if defined COMPILE_FOR_WINDOWS || defined COMPILE_FOR_CYGWIN
 static char RxTmpBuf[256];        // save received data to this buffer for half-duplex
@@ -1584,6 +1584,7 @@ static void ReadArguments(ISP_ENVIRONMENT *IspEnvironment, unsigned int argc, ch
                        "Version " VERSION_STR " compiled for " COMPILED_FOR ": " __DATE__ ", " __TIME__ "\n"
                        "Copyright (c) by Martin Maurer, 2003-2013, Email: Martin.Maurer@clibb.de\n"
                        "Portions Copyright (c) by Aeolus Development 2004, www.aeolusdevelopment.com\n"
+                       "Improvements by Craig McQueen, https://github.com/cmcqueen/lpc21isp\n"
                        "\n");
 
         DebugPrintf(1, "Syntax:  lpc21isp [Options] file[ file[ ...]] comport baudrate Oscillator_in_kHz\n\n"

--- a/lpc21isp.c
+++ b/lpc21isp.c
@@ -415,7 +415,7 @@ Change-History:
 // Please don't use TABs in the source code !!!
 
 // Don't forget to update the version string that is on the next line
-#define VERSION_STR "1.98"
+#define VERSION_STR "1.99"
 
 #if defined COMPILE_FOR_WINDOWS || defined COMPILE_FOR_CYGWIN
 static char RxTmpBuf[256];        // save received data to this buffer for half-duplex
@@ -1184,7 +1184,7 @@ void DebugPrintf(int level, const char *fmt, ...)
 
 /***************************** ReceiveComPort ***************************/
 /**  Receives a buffer from the open com port. Returns when the buffer is
-filled, the numer of requested linefeeds has been received or the timeout
+filled, the number of requested linefeeds has been received or the timeout
 period has passed. The bootloaders may send 0x0d,0x0a,0x0a or 0x0d,0x0a as
 linefeed pattern
 2013-06-28 Torsten Lang
@@ -1198,7 +1198,7 @@ echoed commands.
 \param [in] ISPEnvironment.
 \param [out] Answer buffer to hold the bytes read from the serial port.
 \param [in] MaxSize the size of buffer pointed to by Answer.
-\param [out] RealSize pointer to a long that returns the amout of the
+\param [out] RealSize pointer to a long that returns the amount of the
 buffer that is actually used.
 \param [in] WantedNr0x0A the maximum number of linefeeds to accept before
 returning.
@@ -1285,7 +1285,7 @@ void ReceiveComPort(ISP_ENVIRONMENT *IspEnvironment,
         }
     } while (((*RealSize) < MaxSize) && (SerialTimeoutCheck(IspEnvironment) == 0) && (nr_of_0x0A < WantedNr0x0A) && !eof);
 
-    /* Torsten Lang 2013-05-06 Store residual data and cut answer after expected nr. of 0x0a */
+    /* Torsten Lang 2013-05-06 Store residual data and cut answer after expected number of 0x0a */
     Answer[*RealSize] = '\0';
     if (endPtr != NULL)
     {

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -90,6 +90,14 @@ static const unsigned int SectorTable_11xx[] =
      4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096
 };
 
+static const unsigned int SectorTable_11x6x[] =
+{
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+     4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
+    32768, 32768, 32768, 32768, 32768
+};
+
 // Used for LPC17xx devices
 static const unsigned int SectorTable_17xx[] =
 {
@@ -209,6 +217,16 @@ static LPC_DEVICE_TYPE LPCtypes[] =
    { 0x00017C40, 0x00000000, 0, "11U37FBD48/401",                128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
    { 0x00007C44, 0x00000000, 0, "11U37HFBD64/401",               128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
    { 0x00007C40, 0x00000000, 0, "11U37FBD64/501",                128,  12, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+
+   /* LPC11[UE]6x see UM10732 */
+   { 0x0000DCC8, 0x00000000, 0, "11U66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC88, 0x00000000, 0, "11U67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC80, 0x00000000, 0, "11U67JBD100",                   128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C08, 0x00000000, 0, "11U68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C00, 0x00000000, 0, "11U68JBD100",                   256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000DCC1, 0x00000000, 0, "11E66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC81, 0x00000000, 0, "11E67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C01, 0x00000000, 0, "11E68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
 
    { 0x3640C02B, 0x00000000, 0, "1224.../101",                    32,   8,  4, 2048, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
    { 0x3642C02B, 0x00000000, 0, "1224.../121",                    48,  12, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -1285,6 +1285,7 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
                                 else
                                 {
                                     // Padding with FF
+                                    DebugPrintf(2, "Padding with FF at 0x%08X\n", Pos + Block * 45 + BlockOffset + IspEnvironment->BinaryOffset);
                                     c = 0xFF;
                                 }
                             }

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -1278,11 +1278,27 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
                             if ( (IspEnvironment->BinaryOffset <  ReturnValueLpcRamStart(IspEnvironment))
                                ||(IspEnvironment->BinaryOffset >= ReturnValueLpcRamStart(IspEnvironment)+(LPCtypes[IspEnvironment->DetectedDevice].RAMSize*1024)))
                             { // Flash: use full memory
-                                c = IspEnvironment->BinaryContent[Pos + Block * 45 + BlockOffset];
+                                if ((Pos + Block * 45 + BlockOffset) < IspEnvironment->BinaryLength)
+                                {
+                                    c = IspEnvironment->BinaryContent[Pos + Block * 45 + BlockOffset];
+                                }
+                                else
+                                {
+                                    // Padding with FF
+                                    c = 0xFF;
+                                }
                             }
                             else
                             { // RAM: Skip first 0x200 bytes, these are used by the download program in LPC21xx
-                                c = IspEnvironment->BinaryContent[Pos + Block * 45 + BlockOffset + 0x200];
+                                if ((Pos + Block * 45 + BlockOffset + 0x200) < IspEnvironment->BinaryLength)
+                                {
+                                    c = IspEnvironment->BinaryContent[Pos + Block * 45 + BlockOffset + 0x200];
+                                }
+                                else
+                                {
+                                    // Padding with zero
+                                    c = 0;
+                                }
                             }
 
                             block_CRC += c;

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -43,6 +43,11 @@ Portions Copyright (c) by Aeolus Development 2004 http://www.aeolusdevelopment.c
 #ifdef LPC_SUPPORT
 #include "lpcprog.h"
 
+#define LPC_FLASHABASE_LPC43XX      0x1A000000
+#define LPC_FLASHBBASE_LPC43XX      0x1B000000
+#define FLASH_BANK_A                0
+#define FLASH_BANK_B                1
+
 static const unsigned int SectorTable_210x[] =
 {
     8192, 8192, 8192, 8192, 8192, 8192, 8192, 8192,
@@ -90,6 +95,7 @@ static const unsigned int SectorTable_11xx[] =
      4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096
 };
 
+// Used for LPC11U6x_E6x devices
 static const unsigned int SectorTable_11x6x[] =
 {
      4096,  4096,  4096,  4096,  4096,  4096,  4096,  4096,
@@ -132,228 +138,228 @@ static int unsigned SectorTable_RAM[]  = { 65000 };
 
 static LPC_DEVICE_TYPE LPCtypes[] =
 {
-   { 0, 0, 0, 0, 0, 0, 0, 0, 0, CHIP_VARIANT_NONE },  /* unknown */
+    { 0, 0, 0, 0, 0, 0, { 0, 0 }, 0, 0, CHIP_VARIANT_NONE },  /* unknown */
 
-   // id,        id2,  use id2, name of product,          flash size, ram size, total number of sector, max copy size, sector table, chip variant
+   // id,        id2,  use id2, name of product,          flash size, ram size, total number of sector, max copy size,         sector table,         chip variant
 
-   { 0x00008100, 0x00000000, 0, "810M021FN8",                      4,   1,  4,  256, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
-   { 0x00008110, 0x00000000, 0, "811M001FDH16",                    8,   2,  8, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
-   { 0x00008120, 0x00000000, 0, "812M101FDH16",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
-   { 0x00008121, 0x00000000, 0, "812M101FD20",                    16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
-   { 0x00008122, 0x00000000, 0, "812M101FDH20",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX  },
+   { 0x00008100, 0x00000000, 0, "810M021FN8",                      4,        1,             {  4,  0 },          256,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008110, 0x00000000, 0, "811M001FDH16",                    8,        2,             {  8,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008120, 0x00000000, 0, "812M101FDH16",                   16,        4,             { 16,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008121, 0x00000000, 0, "812M101FD20",                    16,        4,             { 16,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008122, 0x00000000, 0, "812M101FDH20",                   16,        4,             { 16,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
 
-   { 0x00008241, 0x00000000, 0, "824M201JHI33",                   32,   8, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
-   { 0x00008221, 0x00000000, 0, "822M101JHI33",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
-   { 0x00008242, 0x00000000, 0, "824M201JDH20",                   32,   8, 32, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
-   { 0x00008222, 0x00000000, 0, "822M101JDH20",                   16,   4, 16, 1024, SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008241, 0x00000000, 0, "824M201JHI33",                   32,        8,             { 32,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008221, 0x00000000, 0, "822M101JHI33",                   16,        4,             { 16,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008242, 0x00000000, 0, "824M201JDH20",                   32,        8,             { 32,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
+   { 0x00008222, 0x00000000, 0, "822M101JDH20",                   16,        4,             { 16,  0 },         1024,      SectorTable_8xx,  CHIP_VARIANT_LPC8XX },
 
-   { 0x2500102B, 0x00000000, 0, "1102",                           32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2500102B, 0x00000000, 0, "1102",                           32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
 
-   { 0x0A07102B, 0x00000000, 0, "1110.../002",                     4,   1,  1, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1A07102B, 0x00000000, 0, "1110.../002",                     4,   1,  1, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0A16D02B, 0x00000000, 0, "1111.../002",                     8,   2,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1A16D02B, 0x00000000, 0, "1111.../002",                     8,   2,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x041E502B, 0x00000000, 0, "1111.../101",                     8,   2,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2516D02B, 0x00000000, 0, "1111.../102",                     8,   2,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00010013, 0x00000000, 0, "1111.../103",                     8,   2,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0416502B, 0x00000000, 0, "1111.../201",                     8,   4,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2516902B, 0x00000000, 0, "1111.../202",                     8,   4,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00010012, 0x00000000, 0, "1111.../203",                     8,   4,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x042D502B, 0x00000000, 0, "1112.../101",                    16,   2,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2524D02B, 0x00000000, 0, "1112.../102",                    16,   2,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0A24902B, 0x00000000, 0, "1112.../102",                    16,   4,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1A24902B, 0x00000000, 0, "1112.../102",                    16,   4,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00020023, 0x00000000, 0, "1112.../103",                    16,   2,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0425502B, 0x00000000, 0, "1112.../201",                    16,   4,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2524902B, 0x00000000, 0, "1112.../202",                    16,   4,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00020022, 0x00000000, 0, "1112.../203",                    16,   4,  4, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0434502B, 0x00000000, 0, "1113.../201",                    24,   4,  6, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2532902B, 0x00000000, 0, "1113.../202",                    24,   4,  6, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00030032, 0x00000000, 0, "1113.../203",                    24,   4,  6, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0434102B, 0x00000000, 0, "1113.../301",                    24,   8,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2532102B, 0x00000000, 0, "1113.../302",                    24,   8,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00030030, 0x00000000, 0, "1113.../303",                    24,   8,  6, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0A40902B, 0x00000000, 0, "1114.../102",                    32,   4,  8, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1A40902B, 0x00000000, 0, "1114.../102",                    32,   4,  8, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0444502B, 0x00000000, 0, "1114.../201",                    32,   4,  8, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2540902B, 0x00000000, 0, "1114.../202",                    32,   4,  8, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040042, 0x00000000, 0, "1114.../203",                    32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x0444102B, 0x00000000, 0, "1114.../301",                    32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x2540102B, 0x00000000, 0, "1114.../302",                    32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040040, 0x00000000, 0, "1114.../303",                    32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040060, 0x00000000, 0, "1114.../323",                    32,   8, 12, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00040070, 0x00000000, 0, "1114.../333",                    32,   8, 14, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x00050080, 0x00000000, 0, "1115.../303",                    64,   8, 16, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0A07102B, 0x00000000, 0, "1110.../002",                     4,        1,             {  1,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1A07102B, 0x00000000, 0, "1110.../002",                     4,        1,             {  1,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0A16D02B, 0x00000000, 0, "1111.../002",                     8,        2,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1A16D02B, 0x00000000, 0, "1111.../002",                     8,        2,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x041E502B, 0x00000000, 0, "1111.../101",                     8,        2,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2516D02B, 0x00000000, 0, "1111.../102",                     8,        2,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00010013, 0x00000000, 0, "1111.../103",                     8,        2,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0416502B, 0x00000000, 0, "1111.../201",                     8,        4,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2516902B, 0x00000000, 0, "1111.../202",                     8,        4,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00010012, 0x00000000, 0, "1111.../203",                     8,        4,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x042D502B, 0x00000000, 0, "1112.../101",                    16,        2,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2524D02B, 0x00000000, 0, "1112.../102",                    16,        2,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0A24902B, 0x00000000, 0, "1112.../102",                    16,        4,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1A24902B, 0x00000000, 0, "1112.../102",                    16,        4,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00020023, 0x00000000, 0, "1112.../103",                    16,        2,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0425502B, 0x00000000, 0, "1112.../201",                    16,        4,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2524902B, 0x00000000, 0, "1112.../202",                    16,        4,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00020022, 0x00000000, 0, "1112.../203",                    16,        4,             {  4,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0434502B, 0x00000000, 0, "1113.../201",                    24,        4,             {  6,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2532902B, 0x00000000, 0, "1113.../202",                    24,        4,             {  6,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00030032, 0x00000000, 0, "1113.../203",                    24,        4,             {  6,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0434102B, 0x00000000, 0, "1113.../301",                    24,        8,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2532102B, 0x00000000, 0, "1113.../302",                    24,        8,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00030030, 0x00000000, 0, "1113.../303",                    24,        8,             {  6,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0A40902B, 0x00000000, 0, "1114.../102",                    32,        4,             {  8,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1A40902B, 0x00000000, 0, "1114.../102",                    32,        4,             {  8,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0444502B, 0x00000000, 0, "1114.../201",                    32,        4,             {  8,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2540902B, 0x00000000, 0, "1114.../202",                    32,        4,             {  8,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040042, 0x00000000, 0, "1114.../203",                    32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x0444102B, 0x00000000, 0, "1114.../301",                    32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x2540102B, 0x00000000, 0, "1114.../302",                    32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040040, 0x00000000, 0, "1114.../303",                    32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040060, 0x00000000, 0, "1114.../323",                    32,        8,             { 12,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00040070, 0x00000000, 0, "1114.../333",                    32,        8,             { 14,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x00050080, 0x00000000, 0, "1115.../303",                    64,        8,             { 16,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
 
-   { 0x1421102B, 0x00000000, 0, "11C12.../301",                   16,   8,  4, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1440102B, 0x00000000, 0, "11C14.../301",                   32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1431102B, 0x00000000, 0, "11C22.../301",                   16,   8,  4, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
-   { 0x1430102B, 0x00000000, 0, "11C24.../301",                   32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1421102B, 0x00000000, 0, "11C12.../301",                   16,        8,             {  4,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1440102B, 0x00000000, 0, "11C14.../301",                   32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1431102B, 0x00000000, 0, "11C22.../301",                   16,        8,             {  4,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
+   { 0x1430102B, 0x00000000, 0, "11C24.../301",                   32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX },
 
-   { 0x293E902B, 0x00000000, 0, "11E11FHN33/101",                  8,   4,  2, 1024, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x2954502B, 0x00000000, 0, "11E12FBD48/201",                 16,   6,  4, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x296A102B, 0x00000000, 0, "11E13FBD48/301",                 24,   8,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x2980102B, 0x00000000, 0, "11E14(FHN33,FBD48,FBD64)/401",   32,  10,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x00009C41, 0x00000000, 0, "11E36(FBD64,FHN33)/501",         96,  12, 24, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x00007C45, 0x00000000, 0, "11E37HFBD64/401",               128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
-   { 0x00007C41, 0x00000000, 0, "11E37(FBD48,FBD64)/501",        128,  12, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x293E902B, 0x00000000, 0, "11E11FHN33/101",                  8,        4,             {  2,  0 },         1024,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x2954502B, 0x00000000, 0, "11E12FBD48/201",                 16,        6,             {  4,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x296A102B, 0x00000000, 0, "11E13FBD48/301",                 24,        8,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x2980102B, 0x00000000, 0, "11E14(FHN33,FBD48,FBD64)/401",   32,       10,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x00009C41, 0x00000000, 0, "11E36(FBD64,FHN33)/501",         96,       12,             { 24,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x00007C45, 0x00000000, 0, "11E37HFBD64/401",               128,       10,             { 32,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
+   { 0x00007C41, 0x00000000, 0, "11E37(FBD48,FBD64)/501",        128,       12,             { 32,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10518 Rev. 3 -- 25 Nov 2013 */
 
-   { 0x095C802B, 0x00000000, 0, "11U12(FHN33,FBD48)/201",         16,   6,  4, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x295C802B, 0x00000000, 0, "11U12(FHN33,FBD48)/201",         16,   6,  4, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x097A802B, 0x00000000, 0, "11U13FBD48/201",                 24,   6,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x297A802B, 0x00000000, 0, "11U13FBD48/201",                 24,   6,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0998802B, 0x00000000, 0, "11U14FHN33/201",                 32,   6,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x2998802B, 0x00000000, 0, "11U14(FHN,FHI)33/201",           32,   6,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0998802B, 0x00000000, 0, "11U14(FBD,FET)48/201",           32,   6,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x2998802B, 0x00000000, 0, "11U14(FBD,FET)48/201",           32,   6,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x2972402B, 0x00000000, 0, "11U23FBD48/301",                 24,   8,  6, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x2988402B, 0x00000000, 0, "11U24(FHI33,FBD48,FET48)/301",   32,   8,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x2980002B, 0x00000000, 0, "11U24(FHN33,FBD48,FBD64)/401",   32,  10,  8, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0003D440, 0x00000000, 0, "11U34(FHN33,FBD48)/311",         40,   8, 10, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0001CC40, 0x00000000, 0, "11U34(FHN33,FBD48)/421",         48,  10, 12, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0001BC40, 0x00000000, 0, "11U35(FHN33,FBD48,FBD64)/401",   64,  10, 16, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x0000BC40, 0x00000000, 0, "11U35(FHI33,FET48)/501",         64,  12, 16, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x00019C40, 0x00000000, 0, "11U36(FBD48,FBD64)/401",         96,  10, 24, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x00017C40, 0x00000000, 0, "11U37FBD48/401",                128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x00007C44, 0x00000000, 0, "11U37HFBD64/401",               128,  10, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
-   { 0x00007C40, 0x00000000, 0, "11U37FBD64/501",                128,  12, 32, 4096, SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x095C802B, 0x00000000, 0, "11U12(FHN33,FBD48)/201",         16,        6,             {  4,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x295C802B, 0x00000000, 0, "11U12(FHN33,FBD48)/201",         16,        6,             {  4,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x097A802B, 0x00000000, 0, "11U13FBD48/201",                 24,        6,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x297A802B, 0x00000000, 0, "11U13FBD48/201",                 24,        6,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0998802B, 0x00000000, 0, "11U14FHN33/201",                 32,        6,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x2998802B, 0x00000000, 0, "11U14(FHN,FHI)33/201",           32,        6,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0998802B, 0x00000000, 0, "11U14(FBD,FET)48/201",           32,        6,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x2998802B, 0x00000000, 0, "11U14(FBD,FET)48/201",           32,        6,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x2972402B, 0x00000000, 0, "11U23FBD48/301",                 24,        8,             {  6,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x2988402B, 0x00000000, 0, "11U24(FHI33,FBD48,FET48)/301",   32,        8,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x2980002B, 0x00000000, 0, "11U24(FHN33,FBD48,FBD64)/401",   32,       10,             {  8,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0003D440, 0x00000000, 0, "11U34(FHN33,FBD48)/311",         40,        8,             { 10,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0001CC40, 0x00000000, 0, "11U34(FHN33,FBD48)/421",         48,       10,             { 12,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0001BC40, 0x00000000, 0, "11U35(FHN33,FBD48,FBD64)/401",   64,       10,             { 16,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x0000BC40, 0x00000000, 0, "11U35(FHI33,FET48)/501",         64,       12,             { 16,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x00019C40, 0x00000000, 0, "11U36(FBD48,FBD64)/401",         96,       10,             { 24,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x00017C40, 0x00000000, 0, "11U37FBD48/401",                128,       10,             { 32,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x00007C44, 0x00000000, 0, "11U37HFBD64/401",               128,       10,             { 32,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
+   { 0x00007C40, 0x00000000, 0, "11U37FBD64/501",                128,       12,             { 32,  0 },         4096,      SectorTable_11xx, CHIP_VARIANT_LPC11XX }, /* From UM10462 Rev. 5 -- 20 Nov 2013 */
 
    /* LPC11[UE]6x see UM10732 */
-   { 0x0000DCC8, 0x00000000, 0, "11U66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x0000BC88, 0x00000000, 0, "11U67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x0000BC80, 0x00000000, 0, "11U67JBD100",                   128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x00007C08, 0x00000000, 0, "11U68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x00007C00, 0x00000000, 0, "11U68JBD100",                   256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x0000DCC1, 0x00000000, 0, "11E66",                          64,   8, 16, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x0000BC81, 0x00000000, 0, "11E67",                         128,  16, 25, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
-   { 0x00007C01, 0x00000000, 0, "11E68",                         256,  32, 29, 4096, SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000DCC8, 0x00000000, 0, "11U66JBD48",                     64,       12,             { 16,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC88, 0x00000000, 0, "11U67JBD48/64",                 128,       20,             { 25,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC80, 0x00000000, 0, "11U67JBD100",                   128,       20,             { 25,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C08, 0x00000000, 0, "11U68JBD48/64",                 256,       36,             { 29,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C00, 0x00000000, 0, "11U68JBD100",                   256,       36,             { 29,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000DCC1, 0x00000000, 0, "11E66JBD48",                     64,       10,             { 16,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x0000BC81, 0x00000000, 0, "11E67JBD48/64/100",             128,       18,             { 25,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
+   { 0x00007C01, 0x00000000, 0, "11E68JBD48/64/100",             256,       34,             { 29,  0 },         4096,     SectorTable_11x6x, CHIP_VARIANT_LPC11XX },
 
-   { 0x3640C02B, 0x00000000, 0, "1224.../101",                    32,   8,  4, 2048, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x3642C02B, 0x00000000, 0, "1224.../121",                    48,  12, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x3650002B, 0x00000000, 0, "1225.../301",                    64,  16, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x3652002B, 0x00000000, 0, "1225.../321",                    80,  20, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x3660002B, 0x00000000, 0, "1226",                           96,  24, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
-   { 0x3670002B, 0x00000000, 0, "1227",                          128,  32, 32, 4096, SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3640C02B, 0x00000000, 0, "1224.../101",                    32,        8,             {  4,  0 },         2048,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3642C02B, 0x00000000, 0, "1224.../121",                    48,       12,             { 32,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3650002B, 0x00000000, 0, "1225.../301",                    64,       16,             { 32,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3652002B, 0x00000000, 0, "1225.../321",                    80,       20,             { 32,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3660002B, 0x00000000, 0, "1226",                           96,       24,             { 32,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
+   { 0x3670002B, 0x00000000, 0, "1227",                          128,       32,             { 32,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC11XX },
 
-   { 0x2C42502B, 0x00000000, 0, "1311",                            8,   4,  2, 1024, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x1816902B, 0x00000000, 0, "1311/01",                         8,   4,  2, 1024, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x2C40102B, 0x00000000, 0, "1313",                           32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x1830102B, 0x00000000, 0, "1313/01",                        32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x3A010523, 0x00000000, 0, "1315",                           32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x1A018524, 0x00000000, 0, "1316",                           48,   8, 12, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x1A020525, 0x00000000, 0, "1317",                           64,   8, 16, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x3D01402B, 0x00000000, 0, "1342",                           16,   4,  4, 1024, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x3D00002B, 0x00000000, 0, "1343",                           32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x28010541, 0x00000000, 0, "1345",                           32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x08018542, 0x00000000, 0, "1346",                           48,   8, 12, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
-   { 0x08020543, 0x00000000, 0, "1347",                           64,   8, 16, 4096, SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x2C42502B, 0x00000000, 0, "1311",                            8,        4,             {  2,  0 },         1024,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x1816902B, 0x00000000, 0, "1311/01",                         8,        4,             {  2,  0 },         1024,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x2C40102B, 0x00000000, 0, "1313",                           32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x1830102B, 0x00000000, 0, "1313/01",                        32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x3A010523, 0x00000000, 0, "1315",                           32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x1A018524, 0x00000000, 0, "1316",                           48,        8,             { 12,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x1A020525, 0x00000000, 0, "1317",                           64,        8,             { 16,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x3D01402B, 0x00000000, 0, "1342",                           16,        4,             {  4,  0 },         1024,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x3D00002B, 0x00000000, 0, "1343",                           32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x28010541, 0x00000000, 0, "1345",                           32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x08018542, 0x00000000, 0, "1346",                           48,        8,             { 12,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
+   { 0x08020543, 0x00000000, 0, "1347",                           64,        8,             { 16,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC13XX },
 
-   { 0x25001118, 0x00000000, 0, "1751",                           32,   8,  8, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x25001121, 0x00000000, 0, "1752",                           64,  16, 16, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x25011722, 0x00000000, 0, "1754",                          128,  32, 18, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x25011723, 0x00000000, 0, "1756",                          256,  32, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x25013F37, 0x00000000, 0, "1758",                          512,  64, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x25113737, 0x00000000, 0, "1759",                          512,  64, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26012033, 0x00000000, 0, "1763",                          256,  64, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26011922, 0x00000000, 0, "1764",                          128,  32, 18, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26013733, 0x00000000, 0, "1765",                          256,  64, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26013F33, 0x00000000, 0, "1766",                          256,  64, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26012837, 0x00000000, 0, "1767",                          512,  64, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26013F37, 0x00000000, 0, "1768",                          512,  64, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x26113F37, 0x00000000, 0, "1769",                          512,  64, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25001118, 0x00000000, 0, "1751",                           32,        8,             {  8,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25001121, 0x00000000, 0, "1752",                           64,       16,             { 16,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25011722, 0x00000000, 0, "1754",                          128,       32,             { 18,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25011723, 0x00000000, 0, "1756",                          256,       32,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25013F37, 0x00000000, 0, "1758",                          512,       64,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x25113737, 0x00000000, 0, "1759",                          512,       64,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26012033, 0x00000000, 0, "1763",                          256,       64,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26011922, 0x00000000, 0, "1764",                          128,       32,             { 18,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26013733, 0x00000000, 0, "1765",                          256,       64,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26013F33, 0x00000000, 0, "1766",                          256,       64,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26012837, 0x00000000, 0, "1767",                          512,       64,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26013F37, 0x00000000, 0, "1768",                          512,       64,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x26113F37, 0x00000000, 0, "1769",                          512,       64,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
 
-   { 0x27011132, 0x00000000, 0, "1774",                          128,  40, 18, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x27191F43, 0x00000000, 0, "1776",                          256,  80, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x27193747, 0x00000000, 0, "1777",                          512,  96, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x27193F47, 0x00000000, 0, "1778",                          512,  96, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x281D1743, 0x00000000, 0, "1785",                          256,  80, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x281D1F43, 0x00000000, 0, "1786",                          256,  80, 22, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x281D3747, 0x00000000, 0, "1787",                          512,  96, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
-   { 0x281D3F47, 0x00000000, 0, "1788",                          512,  96, 30, 4096, SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x27011132, 0x00000000, 0, "1774",                          128,       40,             { 18,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x27191F43, 0x00000000, 0, "1776",                          256,       80,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x27193747, 0x00000000, 0, "1777",                          512,       96,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x27193F47, 0x00000000, 0, "1778",                          512,       96,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x281D1743, 0x00000000, 0, "1785",                          256,       80,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x281D1F43, 0x00000000, 0, "1786",                          256,       80,             { 22,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x281D3747, 0x00000000, 0, "1787",                          512,       96,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
+   { 0x281D3F47, 0x00000000, 0, "1788",                          512,       96,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
 
    // LPC18xx
-   { 0xF00B1B3F, 0x00000000, 1, "1810",                            0,  32,  0, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001D830, 0x00000000, 1, "1812",                          512,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1813",                          512,  32, 11, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1815",                          768,  32, 13, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1817",                         1024,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF00A9B3C, 0x00000000, 1, "1820",                            0,  32,  0, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001D830, 0x00000000, 1, "1822",                          512,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1823",                          512,  32, 11, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1825",                          768,  32, 13, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1827",                         1024,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF0009A30, 0x00000000, 1, "1830",                            0,  32,  0, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001DA30, 0x00000044, 1, "1833",                          512,  32, 11, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001DA30, 0x00000000, 1, "1837",                         1024,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF0009830, 0x00000000, 1, "1850",                            0,  32,  0, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001D830, 0x00000044, 1, "1853",                          512,  32, 11, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1857",                         1024,  32, 15, 8192, SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00B1B3F, 0x00000000, 1, "1810",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF001D830, 0x00000000, 1, "1812",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1813",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1815",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1817",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00A9B3C, 0x00000000, 1, "1820",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF001D830, 0x00000000, 1, "1822",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1823",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1825",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1827",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF0009A30, 0x00000000, 1, "1830",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF001DA30, 0x00000044, 1, "1833",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001DA30, 0x00000000, 1, "1837",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF0009830, 0x00000000, 1, "1850",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF001D830, 0x00000044, 1, "1853",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001D830, 0x00000000, 1, "1857",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
 
-   { 0x0004FF11, 0x00000000, 0, "2103",                           32,   8,  8, 4096, SectorTable_2103, CHIP_VARIANT_LPC2XXX },
-   { 0xFFF0FF12, 0x00000000, 0, "2104",                          128,  16, 15, 8192, SectorTable_210x, CHIP_VARIANT_LPC2XXX },
-   { 0xFFF0FF22, 0x00000000, 0, "2105",                          128,  32, 15, 8192, SectorTable_210x, CHIP_VARIANT_LPC2XXX },
-   { 0xFFF0FF32, 0x00000000, 0, "2106",                          128,  64, 15, 8192, SectorTable_210x, CHIP_VARIANT_LPC2XXX },
-   { 0x0201FF01, 0x00000000, 0, "2109",                           64,   8,  8, 4096, SectorTable_2109, CHIP_VARIANT_LPC2XXX },
-   { 0x0101FF12, 0x00000000, 0, "2114",                          128,  16, 15, 8192, SectorTable_211x, CHIP_VARIANT_LPC2XXX },
-   { 0x0201FF12, 0x00000000, 0, "2119",                          128,  16, 15, 8192, SectorTable_211x, CHIP_VARIANT_LPC2XXX },
-   { 0x0101FF13, 0x00000000, 0, "2124",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
-   { 0x0201FF13, 0x00000000, 0, "2129",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
-   { 0x0002FF01, 0x00000000, 0, "2131",                           32,   8,  8, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0002FF11, 0x00000000, 0, "2132",                           64,  16,  9, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0002FF12, 0x00000000, 0, "2134",                          128,  16, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0002FF23, 0x00000000, 0, "2136",                          256,  32, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0002FF25, 0x00000000, 0, "2138",                          512,  32, 27, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0402FF01, 0x00000000, 0, "2141",                           32,   8,  8, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0402FF11, 0x00000000, 0, "2142",                           64,  16,  9, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0402FF12, 0x00000000, 0, "2144",                          128,  16, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0402FF23, 0x00000000, 0, "2146",                          256,  40, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0402FF25, 0x00000000, 0, "2148",                          512,  40, 27, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0301FF13, 0x00000000, 0, "2194",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
-   { 0x0301FF12, 0x00000000, 0, "2210",                            0,  16,  0, 8192, SectorTable_211x, CHIP_VARIANT_LPC2XXX }, /* table is a "don't care" */
-   { 0x0401FF12, 0x00000000, 0, "2212",                          128,  16, 15, 8192, SectorTable_211x, CHIP_VARIANT_LPC2XXX },
-   { 0x0601FF13, 0x00000000, 0, "2214",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x0004FF11, 0x00000000, 0, "2103",                           32,        8,             {  8,  0 },         4096,      SectorTable_2103, CHIP_VARIANT_LPC2XXX },
+   { 0xFFF0FF12, 0x00000000, 0, "2104",                          128,       16,             { 15,  0 },         8192,      SectorTable_210x, CHIP_VARIANT_LPC2XXX },
+   { 0xFFF0FF22, 0x00000000, 0, "2105",                          128,       32,             { 15,  0 },         8192,      SectorTable_210x, CHIP_VARIANT_LPC2XXX },
+   { 0xFFF0FF32, 0x00000000, 0, "2106",                          128,       64,             { 15,  0 },         8192,      SectorTable_210x, CHIP_VARIANT_LPC2XXX },
+   { 0x0201FF01, 0x00000000, 0, "2109",                           64,        8,             {  8,  0 },         4096,      SectorTable_2109, CHIP_VARIANT_LPC2XXX },
+   { 0x0101FF12, 0x00000000, 0, "2114",                          128,       16,             { 15,  0 },         8192,      SectorTable_211x, CHIP_VARIANT_LPC2XXX },
+   { 0x0201FF12, 0x00000000, 0, "2119",                          128,       16,             { 15,  0 },         8192,      SectorTable_211x, CHIP_VARIANT_LPC2XXX },
+   { 0x0101FF13, 0x00000000, 0, "2124",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x0201FF13, 0x00000000, 0, "2129",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x0002FF01, 0x00000000, 0, "2131",                           32,        8,             {  8,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0002FF11, 0x00000000, 0, "2132",                           64,       16,             {  9,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0002FF12, 0x00000000, 0, "2134",                          128,       16,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0002FF23, 0x00000000, 0, "2136",                          256,       32,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0002FF25, 0x00000000, 0, "2138",                          512,       32,             { 27,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0402FF01, 0x00000000, 0, "2141",                           32,        8,             {  8,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0402FF11, 0x00000000, 0, "2142",                           64,       16,             {  9,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0402FF12, 0x00000000, 0, "2144",                          128,       16,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0402FF23, 0x00000000, 0, "2146",                          256,       40,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0402FF25, 0x00000000, 0, "2148",                          512,       40,             { 27,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0301FF13, 0x00000000, 0, "2194",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x0301FF12, 0x00000000, 0, "2210",                            0,       16,             {  0,  0 },         8192,      SectorTable_211x, CHIP_VARIANT_LPC2XXX }, /* table is a "don't care" */
+   { 0x0401FF12, 0x00000000, 0, "2212",                          128,       16,             { 15,  0 },         8192,      SectorTable_211x, CHIP_VARIANT_LPC2XXX },
+   { 0x0601FF13, 0x00000000, 0, "2214",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
    /*                           "2290"; same id as the LPC2210 */
-   { 0x0401FF13, 0x00000000, 0, "2292",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
-   { 0x0501FF13, 0x00000000, 0, "2294",                          256,  16, 17, 8192, SectorTable_212x, CHIP_VARIANT_LPC2XXX },
-   { 0x1600F701, 0x00000000, 0, "2361",                          128,  34, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 4.1 -- 5 Sep 2012 */
-   { 0x1600FF22, 0x00000000, 0, "2362",                          128,  34, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 4.1 -- 5 Sep 2012 */
-   { 0x0603FB02, 0x00000000, 0, "2364",                          128,  34, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
-   { 0x1600F902, 0x00000000, 0, "2364",                          128,  34, 11, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1600E823, 0x00000000, 0, "2365",                          256,  58, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0603FB23, 0x00000000, 0, "2366",                          256,  58, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
-   { 0x1600F923, 0x00000000, 0, "2366",                          256,  58, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1600E825, 0x00000000, 0, "2367",                          512,  58, 15, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0603FB25, 0x00000000, 0, "2368",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
-   { 0x1600F925, 0x00000000, 0, "2368",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1700E825, 0x00000000, 0, "2377",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x0703FF25, 0x00000000, 0, "2378",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
-   { 0x1600FD25, 0x00000000, 0, "2378",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 29 October 2007 */
-   { 0x1700FD25, 0x00000000, 0, "2378",                          512,  58, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1700FF35, 0x00000000, 0, "2387",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 03 -- 25 August 2008 */
-   { 0x1800F935, 0x00000000, 0, "2387",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1800FF35, 0x00000000, 0, "2388",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1500FF35, 0x00000000, 0, "2458",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1600FF30, 0x00000000, 0, "2460",                            0,  98,  0, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1600FF35, 0x00000000, 0, "2468",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1701FF30, 0x00000000, 0, "2470",                            0,  98,  0, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
-   { 0x1701FF35, 0x00000000, 0, "2478",                          512,  98, 28, 4096, SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0401FF13, 0x00000000, 0, "2292",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x0501FF13, 0x00000000, 0, "2294",                          256,       16,             { 17,  0 },         8192,      SectorTable_212x, CHIP_VARIANT_LPC2XXX },
+   { 0x1600F701, 0x00000000, 0, "2361",                          128,       34,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 4.1 -- 5 Sep 2012 */
+   { 0x1600FF22, 0x00000000, 0, "2362",                          128,       34,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 4.1 -- 5 Sep 2012 */
+   { 0x0603FB02, 0x00000000, 0, "2364",                          128,       34,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
+   { 0x1600F902, 0x00000000, 0, "2364",                          128,       34,             { 11,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1600E823, 0x00000000, 0, "2365",                          256,       58,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0603FB23, 0x00000000, 0, "2366",                          256,       58,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
+   { 0x1600F923, 0x00000000, 0, "2366",                          256,       58,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1600E825, 0x00000000, 0, "2367",                          512,       58,             { 15,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0603FB25, 0x00000000, 0, "2368",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
+   { 0x1600F925, 0x00000000, 0, "2368",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1700E825, 0x00000000, 0, "2377",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x0703FF25, 0x00000000, 0, "2378",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 6 July 2007 */
+   { 0x1600FD25, 0x00000000, 0, "2378",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 01 -- 29 October 2007 */
+   { 0x1700FD25, 0x00000000, 0, "2378",                          512,       58,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1700FF35, 0x00000000, 0, "2387",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX }, /* From UM10211 Rev. 03 -- 25 August 2008 */
+   { 0x1800F935, 0x00000000, 0, "2387",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1800FF35, 0x00000000, 0, "2388",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1500FF35, 0x00000000, 0, "2458",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1600FF30, 0x00000000, 0, "2460",                            0,       98,             {  0,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1600FF35, 0x00000000, 0, "2468",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1701FF30, 0x00000000, 0, "2470",                            0,       98,             {  0,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
+   { 0x1701FF35, 0x00000000, 0, "2478",                          512,       98,             { 28,  0 },         4096,      SectorTable_213x, CHIP_VARIANT_LPC2XXX },
 
-   { 0xA00A8B3F, 0x00000000, 1, "4310",                            0, 168,  0, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
-   { 0xA00BCB3F, 0x00000080, 1, "4312",                          512, 104, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA00BCB3F, 0x00000044, 1, "4313",                          512, 104, 11, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA001CB3F, 0x00000022, 1, "4315",                          768, 136, 13, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA001CB3F, 0x00000000, 1, "4317",                         1024, 136, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA0008B3C, 0x00000000, 1, "4320",                            0, 200,  0, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
-   { 0xA00BCB3C, 0x00000080, 1, "4322",                          512, 104, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA00BCB3C, 0x00000044, 1, "4323",                          512, 104, 11, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA001CB3C, 0x00000022, 1, "4325",                          768, 136, 13, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA001CB3C, 0x00000000, 1, "4327",                         1024, 136, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA0000A30, 0x00000000, 1, "4330",                            0, 264,  0, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
-   { 0xA001CA30, 0x00000044, 1, "4333",                          512, 512, 11, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA001CA30, 0x00000000, 1, "4337",                         1024, 512, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
-   { 0xA0000830, 0x00000000, 1, "4350",                            0, 264,  0, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
-   { 0xA001C830, 0x00000044, 1, "4353",                          512, 512, 11, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
-   { 0xA001C830, 0x00000000, 1, "4357",                         1024, 512, 15, 4096, SectorTable_43xx, CHIP_VARIANT_LPC43XX }  /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA00A8B3F, 0x00000000, 1, "4310",                            0,      168,             {  0,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA00BCB3F, 0x00000080, 1, "4312",                          512,      104,             { 15,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA00BCB3F, 0x00000044, 1, "4313",                          512,      104,             { 11, 11 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA001CB3F, 0x00000022, 1, "4315",                          768,      136,             { 13, 13 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA001CB3F, 0x00000000, 1, "4317",                         1024,      136,             { 15, 15 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA0008B3C, 0x00000000, 1, "4320",                            0,      200,             {  0,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA00BCB3C, 0x00000080, 1, "4322",                          512,      104,             { 15,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA00BCB3C, 0x00000044, 1, "4323",                          512,      104,             { 11, 11 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA001CB3C, 0x00000022, 1, "4325",                          768,      136,             { 13, 13 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA001CB3C, 0x00000000, 1, "4327",                         1024,      136,             { 15, 15 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA0000A30, 0x00000000, 1, "4330",                            0,      264,             {  0,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA001CA30, 0x00000044, 1, "4333",                          512,      512,             { 11, 11 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA001CA30, 0x00000000, 1, "4337",                         1024,      512,             { 15, 15 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* info not yet available */
+   { 0xA0000830, 0x00000000, 1, "4350",                            0,      264,             {  0,  0 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA001C830, 0x00000044, 1, "4353",                          512,      512,             { 11, 11 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }, /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
+   { 0xA001C830, 0x00000000, 1, "4357",                         1024,      512,             { 15, 15 },         4096,      SectorTable_43xx, CHIP_VARIANT_LPC43XX }  /* From UM10503 Rev. 1.4 -- 3 Sep 2012 */
 };
 
 /***************************** NXP Download *********************************/
@@ -599,6 +605,9 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
     unsigned long Sector;
     unsigned long SectorLength;
     unsigned long SectorStart, SectorOffset, SectorChunk;
+    unsigned long FlashBank = FLASH_BANK_A;
+    unsigned long FlashBankSector;
+    unsigned long FlashBankSectorStart;
     char tmpString[128];
     char uuencode_table[64];
     int Line;
@@ -999,9 +1008,9 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
     if ( (IspEnvironment->BinaryOffset >= ReturnValueLpcRamStart(IspEnvironment))
        &&(IspEnvironment->BinaryOffset + IspEnvironment->BinaryLength <= ReturnValueLpcRamStart(IspEnvironment)+(LPCtypes[IspEnvironment->DetectedDevice].RAMSize*1024)))
     {
-        LPCtypes[IspEnvironment->DetectedDevice].FlashSectors = 1;
-        LPCtypes[IspEnvironment->DetectedDevice].MaxCopySize  = LPCtypes[IspEnvironment->DetectedDevice].RAMSize*1024 - (ReturnValueLpcRamBase(IspEnvironment) - ReturnValueLpcRamStart(IspEnvironment));
-        LPCtypes[IspEnvironment->DetectedDevice].SectorTable  = SectorTable_RAM;
+        LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A] = 1;
+        LPCtypes[IspEnvironment->DetectedDevice].MaxCopySize                = LPCtypes[IspEnvironment->DetectedDevice].RAMSize*1024 - (ReturnValueLpcRamBase(IspEnvironment) - ReturnValueLpcRamStart(IspEnvironment));
+        LPCtypes[IspEnvironment->DetectedDevice].SectorTable                = SectorTable_RAM;
         SectorTable_RAM[0] = LPCtypes[IspEnvironment->DetectedDevice].MaxCopySize;
     }
     if (IspEnvironment->DetectOnly)
@@ -1034,15 +1043,16 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
     {
         DebugPrintf(2, "Wiping Device. ");
 
+        // Check if the chip could have multiple flash banks
         if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
             LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
         {
-            // TODO: Quick and dirty hack to address bank 0
-            sprintf(tmpString, "P %d %d 0\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors-1);
+            DebugPrintf(2, "Flash Bank A. ");
+            sprintf(tmpString, "P %d %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A]-1, FLASH_BANK_A);
         }
         else
         {
-            sprintf(tmpString, "P %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors-1);
+            sprintf(tmpString, "P %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A]-1);
         }
 
         if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
@@ -1051,38 +1061,56 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
             return (WRONG_ANSWER_PREP + GetAndReportErrorNumber(Answer));
         }
 
+        // Check if the chip could have multiple flash banks
         if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
             LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
         {
-            // TODO: Quick and dirty hack to address bank 0
-            sprintf(tmpString, "E %d %d 0\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors-1);
+            sprintf(tmpString, "E %d %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A]-1, FLASH_BANK_A);
         }
         else
         {
-            sprintf(tmpString, "E %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors-1);
+            sprintf(tmpString, "E %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A]-1);
         }
+
         if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
         {
             DebugPrintf(1, "Wrong answer on Erase-Command\n");
             return (WRONG_ANSWER_ERAS + GetAndReportErrorNumber(Answer));
         }
-        DebugPrintf(2, "OK \n");
 
-        if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
-            LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
+        // Check if the chip does have multiple flash banks
+        if (LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_B] > 0)
         {
-          DebugPrintf(2, "ATTENTION: Only bank A was wiped!!!\n");
+            DebugPrintf(2, "Flash Bank B. ");
+            sprintf(tmpString, "P %d %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_B]-1, FLASH_BANK_B);
+
+            if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
+            {
+                DebugPrintf(1, "Wrong answer on Prepare-Command\n");
+                return (WRONG_ANSWER_PREP + GetAndReportErrorNumber(Answer));
+            }
+
+            sprintf(tmpString, "E %d %d %d\r\n", 0, LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_B]-1, FLASH_BANK_B);
+
+            if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
+            {
+                DebugPrintf(1, "Wrong answer on Erase-Command\n");
+                return (WRONG_ANSWER_ERAS + GetAndReportErrorNumber(Answer));
+            }
         }
+
+        DebugPrintf(2, "OK \n");
     }
-    else{
+    else
+    {
         //no wiping requested: erasing sector 0 first
         DebugPrintf(2, "Erasing sector 0 first, to invalidate checksum. ");
 
+        // Check if the chip could have multiple flash banks
         if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
             LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
         {
-            // TODO: Quick and dirty hack to address bank 0
-            sprintf(tmpString, "P %d %d 0\r\n", 0, 0);
+            sprintf(tmpString, "P %d %d %d\r\n", 0, 0, FLASH_BANK_A);
         }
         else
         {
@@ -1095,11 +1123,11 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
             return (WRONG_ANSWER_PREP + GetAndReportErrorNumber(Answer));
         }
 
+        // Check if the chip could have multiple flash banks
         if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
             LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
         {
-            // TODO: Quick and dirty hack to address bank 0
-            sprintf(tmpString, "E %d %d 0\r\n", 0, 0);
+            sprintf(tmpString, "E %d %d %d\r\n", 0, 0, FLASH_BANK_A);
         }
         else
         {
@@ -1111,57 +1139,104 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
             DebugPrintf(1, "Wrong answer on Erase-Command\n");
             return (WRONG_ANSWER_ERAS + GetAndReportErrorNumber(Answer));
         }
+
         DebugPrintf(2, "OK \n");
     }
+
+    // Set the binary offset for cortex m4
+    if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
+        LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
+    {
+        if (IspEnvironment->BinaryOffset == 0)
+        {
+            IspEnvironment->BinaryOffset = LPC_FLASHABASE_LPC43XX;
+        }
+    }
+
     while (1)
     {
-        if (Sector >= LPCtypes[IspEnvironment->DetectedDevice].FlashSectors)
+        if (Sector >= (LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A] + LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_B]))
         {
             DebugPrintf(1, "Program too large; running out of Flash sectors.\n");
             return (PROGRAM_TOO_LARGE);
         }
 
-        DebugPrintf(2, "Sector %ld: ", Sector);
+        FlashBankSectorStart = SectorStart;
+
+        // Check if the last sector (sector 0) of data is being written
+        if ( Sector == 0 )
+        {
+            FlashBank = FLASH_BANK_A;
+            IspEnvironment->BinaryOffset = LPC_FLASHABASE_LPC43XX;
+        }
+        // Detect when a new flash bank starts
+        else if (Sector == LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A])
+        {
+            DebugPrintf(1, "Starting to write to sectors in Flash Bank B.\n");
+            FlashBank = FLASH_BANK_B;
+            FlashBankSectorStart = 0;
+
+            // Set the binary offset for cortex m4
+            if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
+                LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
+            {
+                IspEnvironment->BinaryOffset = LPC_FLASHBBASE_LPC43XX;
+            }
+        }
+
+        // Check if the chip could have multiple flash banks
+        if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
+            LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
+        {
+            FlashBankSector = Sector % LPCtypes[IspEnvironment->DetectedDevice].FlashSectors[FLASH_BANK_A];
+            DebugPrintf(2, "Sector %ld (Flash bank: %c, Sector #%ld): ", Sector, FlashBank == FLASH_BANK_A ? 'A' : 'B', FlashBankSector);
+        }
+        else
+        {
+            FlashBankSector = Sector;
+            DebugPrintf(2, "Sector %ld: ", FlashBankSector);
+        }
+
         fflush(stdout);
 
         if ( (IspEnvironment->BinaryOffset <  ReturnValueLpcRamStart(IspEnvironment))  // Skip Erase when running from RAM
            ||(IspEnvironment->BinaryOffset >= ReturnValueLpcRamStart(IspEnvironment)+(LPCtypes[IspEnvironment->DetectedDevice].RAMSize*1024)))
         {
+            // Check if the chip could have multiple flash banks
             if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
                 LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
             {
-                // TODO: Quick and dirty hack to address bank 0
-                sprintf(tmpString, "P %ld %ld 0\r\n", Sector, Sector);
+                sprintf(tmpString, "P %ld %ld %ld\r\n", FlashBankSector, FlashBankSector, FlashBank);
             }
             else
             {
-                sprintf(tmpString, "P %ld %ld\r\n", Sector, Sector);
+                sprintf(tmpString, "P %ld %ld\r\n", FlashBankSector, FlashBankSector);
             }
 
             if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
             {
-                DebugPrintf(1, "Wrong answer on Prepare-Command (1) (Sector %ld)\n", Sector);
+                DebugPrintf(1, "Wrong answer on Prepare-Command (1) (Sector %ld)\n", FlashBankSector);
                 return (WRONG_ANSWER_PREP + GetAndReportErrorNumber(Answer));
             }
 
             DebugPrintf(2, ".");
             fflush(stdout);
-            if (IspEnvironment->WipeDevice == 0 && (Sector!=0)) //Sector 0 already erased
+            if (IspEnvironment->WipeDevice == 0 && (FlashBankSector!=0)) //Sector 0 already erased
             {
+                // Check if the chip could have multiple flash banks
                 if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
                     LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
                 {
-                    // TODO: Quick and dirty hack to address bank 0
-                    sprintf(tmpString, "E %ld %ld 0\r\n", Sector, Sector);
+                    sprintf(tmpString, "E %ld %ld %ld\r\n", FlashBankSector, FlashBankSector, FlashBank);
                 }
                 else
                 {
-                    sprintf(tmpString, "E %ld %ld\r\n", Sector, Sector);
+                    sprintf(tmpString, "E %ld %ld\r\n", FlashBankSector, FlashBankSector);
                 }
 
                 if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
                 {
-                    DebugPrintf(1, "Wrong answer on Erase-Command (Sector %ld)\n", Sector);
+                    DebugPrintf(1, "Wrong answer on Erase-Command (Sector %ld)\n", FlashBankSector);
                     return (WRONG_ANSWER_ERAS + GetAndReportErrorNumber(Answer));
                 }
 
@@ -1170,7 +1245,7 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
             }
         }
 
-        SectorLength = LPCtypes[IspEnvironment->DetectedDevice].SectorTable[Sector];
+        SectorLength = LPCtypes[IspEnvironment->DetectedDevice].SectorTable[FlashBankSector];
         if (SectorLength > IspEnvironment->BinaryLength - SectorStart)
         {
             SectorLength = IspEnvironment->BinaryLength - SectorStart;
@@ -1505,17 +1580,16 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
                 if (LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC43XX ||
                     LPCtypes[IspEnvironment->DetectedDevice].ChipVariant == CHIP_VARIANT_LPC18XX)
                 {
-                    // TODO: Quick and dirty hack to address bank 0
-                    sprintf(tmpString, "P %ld %ld 0\r\n", Sector, Sector);
+                    sprintf(tmpString, "P %ld %ld %ld\r\n", FlashBankSector, FlashBankSector, FlashBank);
                 }
                 else
                 {
-                    sprintf(tmpString, "P %ld %ld\r\n", Sector, Sector);
+                    sprintf(tmpString, "P %ld %ld\r\n", FlashBankSector, FlashBankSector);
                 }
 
                 if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
                 {
-                    DebugPrintf(1, "Wrong answer on Prepare-Command (2) (Sector %ld)\n", Sector);
+                    DebugPrintf(1, "Wrong answer on Prepare-Command (2) (Sector %ld)\n", FlashBankSector);
                     return (WRONG_ANSWER_PREP2 + GetAndReportErrorNumber(Answer));
                 }
 
@@ -1543,7 +1617,7 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
                     CopyLength = LPCtypes[IspEnvironment->DetectedDevice].MaxCopySize;
                 }
 
-                sprintf(tmpString, "C %ld %ld %ld\r\n", IspEnvironment->BinaryOffset + SectorStart + SectorOffset, ReturnValueLpcRamBase(IspEnvironment), CopyLength);
+                sprintf(tmpString, "C %ld %ld %ld\r\n", IspEnvironment->BinaryOffset + FlashBankSectorStart + SectorOffset, ReturnValueLpcRamBase(IspEnvironment), CopyLength);
 
                 if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
                 {
@@ -1559,11 +1633,11 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
                     //and the compare result may not be correct.
                     if (SectorStart + SectorOffset<64)
                     {
-                        sprintf(tmpString, "M %d %ld %ld\r\n", 64, ReturnValueLpcRamBase(IspEnvironment) + (64 - SectorStart - SectorOffset), CopyLength-(64 - SectorStart - SectorOffset));
+                        sprintf(tmpString, "M %ld %ld %ld\r\n", IspEnvironment->BinaryOffset + 64, ReturnValueLpcRamBase(IspEnvironment) + (64 - FlashBankSectorStart - SectorOffset), CopyLength-(64 - FlashBankSectorStart - SectorOffset));
                     }
                     else
                     {
-                        sprintf(tmpString, "M %ld %ld %ld\r\n", SectorStart + SectorOffset, ReturnValueLpcRamBase(IspEnvironment), CopyLength);
+                        sprintf(tmpString, "M %ld %ld %ld\r\n", IspEnvironment->BinaryOffset + FlashBankSectorStart + SectorOffset, ReturnValueLpcRamBase(IspEnvironment), CopyLength);
                     }
 
                     if (!SendAndVerify(IspEnvironment, tmpString, Answer, sizeof Answer))
@@ -1575,19 +1649,24 @@ int NxpDownload(ISP_ENVIRONMENT *IspEnvironment)
             }
         }
 
-        DebugPrintf(2, "\n");
+        DebugPrintf(2, "\r\n");
         fflush(stdout);
 
+        // Check if all sectors but the last (sector 0) have been written
         if ((SectorStart + SectorLength) >= IspEnvironment->BinaryLength && Sector!=0)
         {
             Sector = 0;
             SectorStart = 0;
         }
-        else if (Sector == 0) {
+        // Check if all sectors have been written
+        else if (Sector == 0)
+        {
             break;
         }
-        else {
-            SectorStart += LPCtypes[IspEnvironment->DetectedDevice].SectorTable[Sector];
+        // Otherwise setup to write the next sector
+        else
+        {
+            SectorStart += LPCtypes[IspEnvironment->DetectedDevice].SectorTable[FlashBankSector];
             Sector++;
         }
     }

--- a/lpcprog.c
+++ b/lpcprog.c
@@ -278,16 +278,16 @@ static LPC_DEVICE_TYPE LPCtypes[] =
    { 0x281D3F47, 0x00000000, 0, "1788",                          512,       96,             { 30,  0 },         4096,      SectorTable_17xx, CHIP_VARIANT_LPC17XX },
 
    // LPC18xx
-   { 0xF00B1B3F, 0x00000000, 1, "1810",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001D830, 0x00000000, 1, "1812",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1813",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1815",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1817",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF00A9B3C, 0x00000000, 1, "1820",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
-   { 0xF001D830, 0x00000000, 1, "1822",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1823",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1825",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
-   { 0xF001D830, 0x00000000, 1, "1827",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00B5B3F, 0x00000000, 1, "1810",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF00BDB3F, 0x00000080, 1, "1812",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00BDB3F, 0x00000044, 1, "1813",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001DB3F, 0x00000022, 1, "1815",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF001DB3F, 0x00000000, 1, "1817",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00ADB3C, 0x00000000, 1, "1820",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
+   { 0xF00BDB3C, 0x00000080, 1, "1822",                          512,       32,             { 15,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00BDB3C, 0x00000044, 1, "1823",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00BDB3C, 0x00000022, 1, "1825",                          768,       32,             { 13, 13 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
+   { 0xF00BDB3C, 0x00000000, 1, "1827",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
    { 0xF0009A30, 0x00000000, 1, "1830",                            0,       32,             {  0,  0 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX }, // Flashless
    { 0xF001DA30, 0x00000044, 1, "1833",                          512,       32,             { 11, 11 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },
    { 0xF001DA30, 0x00000000, 1, "1837",                         1024,       32,             { 15, 15 },         8192,      SectorTable_18xx, CHIP_VARIANT_LPC18XX },

--- a/lpcprog.h
+++ b/lpcprog.h
@@ -128,11 +128,11 @@ typedef struct
     const unsigned long  id2;
     const unsigned int   EvalId2;
     const char *Product;
-    const unsigned int   FlashSize;     /* in kiB, for informational purposes only */
-    const unsigned int   RAMSize;       /* in kiB, for informational purposes only */
-          unsigned int   FlashSectors;  /* total number of sectors */
-          unsigned int   MaxCopySize;   /* maximum size that can be copied to Flash in a single command */
-    const unsigned int  *SectorTable;   /* pointer to a sector table with constant the sector sizes */
+    const unsigned int   FlashSize;       /* in kiB, for informational purposes only */
+    const unsigned int   RAMSize;         /* in kiB, for informational purposes only */
+          unsigned int   FlashSectors[2]; /* total number of sectors {index = flash bank}*/
+          unsigned int   MaxCopySize;     /* maximum size that can be copied to Flash in a single command */
+    const unsigned int  *SectorTable;     /* pointer to a sector table with constant the sector sizes */
     const CHIP_VARIANT   ChipVariant;
 } LPC_DEVICE_TYPE;
 


### PR DESCRIPTION
It has been tested on LPC 1822 and LPC1837, but LPC1822 needs to modify the code before ISP, and modify other Id codes.

- Available for viewing
* Detasheet UM10430 Rev. 3.1 — 11 September 2019
* Chapter 5: LPC18xx flash programming/ISP and IAP
* Table 39 :LPC18xx part identification numbers